### PR TITLE
Added quil for 1 qubit teleportation.

### DIFF
--- a/teleportation_examples/1q_teleportation.quil
+++ b/teleportation_examples/1q_teleportation.quil
@@ -1,0 +1,15 @@
+# Prepare a bell state
+H 1
+CNOT 1 2
+
+# Teleport qubit 0 to qubit 2
+CNOT 0 1
+H 0
+MEASURE 0 [0]
+MEASURE 1 [1]
+JUMP-UNLESS @NOX [1]
+X 2
+LABEL @NOX
+JUMP-UNLESS @NOZ [0]
+Z 2
+LABEL @NOZ


### PR DESCRIPTION
Added the quil for 1 qubit teleportation. Sends qubit 0 to qubit 2, and without further initialization this will just be the |0> state.