### PR TITLE
Inverse QFT - Implementation and Test

### DIFF
--- a/grove/qft/fourier.py
+++ b/grove/qft/fourier.py
@@ -60,5 +60,37 @@ def qft(qubits):
     return p + bit_reversal(qubits)
 
 
+def inverse_qft(qubits):
+    """
+    Generate a program to compute the inverse quantum Fourier transform on
+    a set of qubits.
+
+    :param qubits: A list of qubit indexes.
+    :return: A Quil program to compute the inverse Fourier transform of the 
+             qubits.
+    """
+    
+    def core_inverse_qft(qubits):
+        q = qubits[0]
+        qs = qubits[1:]
+        if 1 == len(qubits):
+            return [H(q)]
+        else:
+            n = 1 + len(qs)
+            cR = []
+            for idx, i in enumerate(xrange(n - 1, 0, -1)):
+                q_idx = qs[idx]
+                angle = math.pi / 2 ** (n - i)
+                cR.append(CPHASE(-angle)(q, q_idx))
+            return core_inverse_qft(qs) + list(reversed(cR)) + [H(q)]
+    
+    qft_result = pq.Program().inst(core_inverse_qft(qubits))
+    qft_result = qft_result + bit_reversal(qubits)
+    inverse_qft = pq.Program()
+    while len(qft_result.actions) > 0:
+        new_inst = qft_result.actions.pop()[1]
+        inverse_qft.inst(new_inst)
+    return inverse_qft
+
 if __name__ == '__main__':
     print qft([0, 1, 2, 3])

--- a/grove/qft/tests/test_inverse_qft.py
+++ b/grove/qft/tests/test_inverse_qft.py
@@ -45,5 +45,6 @@ def test_multi_qubit_qft():
                                      CPHASE(-0.7853981633974483, 0, 2),
                                      H(1), CPHASE(-1.5707963267948966, 1, 2),
                                      H(2)])
-    
+    print(trial_prog)
+    print(result_prog)
     compare_progs(trial_prog, result_prog)

--- a/grove/qft/tests/test_inverse_qft.py
+++ b/grove/qft/tests/test_inverse_qft.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+#    A collection of tests for the inverse quantum Fourier transform.
+#
+#    Written by Aaron Vontell on January 28th, 2017
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+
+import pyquil.forest as Forest
+from pyquil.gates import X
+from grove.qft.fourier import *
+
+def test_inverse_qft():
+    
+    qvm = Forest.Connection()
+    
+    p = pq.Program()
+    
+    # Apply the QFT to 0, 1, 1, 0, 1, 0 (from n - 1 to 0), apply the QFT^-1,
+    # and verify that the original result is obtained
+    p.inst(X(1), X(2), X(4))
+    p = p + qft([0, 1, 2, 3, 4, 5])
+    p = p + inverse_qft([0, 1, 2, 3, 4, 5])
+    p.measure(0, 0).measure(1, 1).measure(2, 2).measure(3, 3).measure(4, 4).measure(5, 5)
+    wave_fn = qvm.wavefunction(p)
+    result = qvm.run(p, [0, 1, 2, 3, 4, 5])
+    
+    assert result == [[0, 1, 1, 0, 1, 0]]
+    # 010110 = 22, accounting for float precision errors
+    assert abs(wave_fn[0][22] - 1) < 10 ** -9

--- a/grove/qft/tests/test_qft.py
+++ b/grove/qft/tests/test_qft.py
@@ -1,8 +1,5 @@
 ##############################################################################
-#
-#    A collection of tests for the inverse quantum Fourier transform.
-#
-#    Written by Aaron Vontell on January 28th, 2017
+# Copyright 2016-2017 Rigetti Computing
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -15,11 +12,11 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-#
 ##############################################################################
 
-from pyquil.gates import X
-from grove.qft.fourier import *
+from pyquil.gates import *
+from grove.qft.fourier import inverse_qft
+import pyquil.quil as pq
 from grove.pyqaoa.utils import compare_progs # This would be nice to have in
                                              # general purpose Util module
 
@@ -45,6 +42,5 @@ def test_multi_qubit_qft():
                                      CPHASE(-0.7853981633974483, 0, 2),
                                      H(1), CPHASE(-1.5707963267948966, 1, 2),
                                      H(2)])
-    print(trial_prog)
-    print(result_prog)
+    
     compare_progs(trial_prog, result_prog)


### PR DESCRIPTION
I was looking to easily add the inverse QFT to an instruction set, but saw that it was not implemented. Since (I believe, there is surprisingly little literature on the inverse implementation) it is simply the QFT in reverse (with negative angles), I have added it as another method in the `fourier.py` file. I also added a simple test which takes a bit string, applies the QFT followed by the inverse QFT, and verifies that the final result equals the initial result, but note that this relies on the correctness of the QFT (which does not have tests yet as far as I can see).