### PR TITLE
Adjusting W.F. use to pyQuil Wavefunction obj

### DIFF
--- a/docs/qaoa.rst
+++ b/docs/qaoa.rst
@@ -62,6 +62,7 @@ quil program that gives us \\(\\mid \\beta, \\gamma \\rangle \\)  and evaluate t
     param_prog = inst.get_parameterized_program()
     prog = param_prog(t)
     wf, _ = qvm_connection.wavefunction(prog)
+    wf = wf.amplitudes
 
 ``wf`` is now a numpy array of complex-valued amplitudes for each computational
 basis state.  To visualize the distribution iterate over the states and

--- a/grove/pyqaoa/README.md
+++ b/grove/pyqaoa/README.md
@@ -45,7 +45,8 @@ us |beta,gamma> and evaluate the wave function using the **qvm**
 t = np.hstack((inst.betas, inst.gammas))
 param_prog = inst.get_parameterized_program()
 prog = param_prog(t)
-wf = qvm_connection.wavefunction(prog)
+wf, _ = qvm_connection.wavefunction(prog)
+wf = wf.amplitudes
 ```
 
 `wf` is now a numpy array of complex-valued amplitudes for each computational

--- a/grove/pyqaoa/getting-started/QAOA_overview_maxcut.ipynb
+++ b/grove/pyqaoa/getting-started/QAOA_overview_maxcut.ipynb
@@ -135,6 +135,7 @@
     "t = np.hstack((betas, gammas))\n",
     "prog = param_prog(t)\n",
     "wf, _ = inst.qvm.wavefunction(prog)\n",
+    "wf = wf.amplitudes\n",
     "for ii in xrange(2**inst.n_qubits):\n",
     "    print inst.states[ii], np.conj(wf[ii])*wf[ii]"
    ]
@@ -423,15 +424,6 @@
     "probs = ring_cut_inst_3.probabilities(t)\n",
     "plot(ring_cut_inst_3, probs)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -451,7 +443,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -214,7 +214,7 @@ class QAOA(object):
         param_prog = self.get_parameterized_program()
         prog = param_prog(angles)
         wf, _ = self.qvm.wavefunction(prog)
-        wf = wf.reshape((-1, 1))
+        wf = wf.amplitudes.reshape((-1, 1))
         probs = np.zeros_like(wf)
         for xx in xrange(2 ** self.n_qubits):
             probs[xx] = np.conj(wf[xx]) * wf[xx]

--- a/grove/pyqaoa/tests/test_qaoa.py
+++ b/grove/pyqaoa/tests/test_qaoa.py
@@ -21,6 +21,7 @@ import pyquil.forest as qvm_module
 from pyquil.paulis import PauliTerm, PauliSum
 from pyquil.gates import X, Y, Z
 from pyquil.quil import Program
+from pyquil.wavefunction import Wavefunction
 from grove.pyvqe.vqe import VQE
 from mock import Mock, patch
 
@@ -35,7 +36,7 @@ def test_probabilities():
                    -7.67563580e-06 - 1j*7.07106781e-01,
                    -1.17642098e-05 - 1j*7.67538040e-06])
     fakeQVM = Mock(spec=qvm_module.Connection())
-    fakeQVM.wavefunction = Mock(return_value=(wf, 0))
+    fakeQVM.wavefunction = Mock(return_value=(Wavefunction(wf), 0))
     inst = QAOA(fakeQVM, n_qubits, steps=p,
                 rand_seed=42)
 

--- a/grove/pyvqe/tests/test_algorithms.py
+++ b/grove/pyvqe/tests/test_algorithms.py
@@ -16,6 +16,7 @@
 
 from grove.pyvqe.vqe import VQE, parity_even_p
 from pyquil.quil import Program
+from pyquil.wavefunction import Wavefunction
 from pyquil.gates import RX, H, RZ
 from pyquil.paulis import PauliSum, PauliTerm
 from mock import Mock, MagicMock
@@ -73,7 +74,7 @@ def test_expectation():
     minimizer.return_value = fake_result
 
     fake_qvm = Mock(spec=['wavefunction', 'expectation', 'run'])
-    fake_qvm.wavefunction.return_value = (rotation_wavefunction(-2.5), [0])
+    fake_qvm.wavefunction.return_value = (Wavefunction(rotation_wavefunction(-2.5)), [0])
     fake_qvm.expectation.return_value = [0.28366219]
     # for testing expectation
     fake_qvm.run.return_value = [[0], [0]]

--- a/grove/pyvqe/vqe.py
+++ b/grove/pyvqe/vqe.py
@@ -22,7 +22,6 @@ from collections import Counter
 from pyquil.gates import STANDARD_GATES, RX, RY
 from pyquil.paulis import PauliTerm, PauliSum
 
-
 class OptResults(dict):
     """
     Object for holding optimization results from VQE.
@@ -210,6 +209,7 @@ class VQE(object):
         if isinstance(pauli_sum, np.ndarray):
             # debug mode by passing an array
             wf, _ = qvm.wavefunction(pyquil_prog)
+            wf = np.reshape(wf.amplitudes, (-1, 1))
             average_exp = np.conj(wf).T.dot(pauli_sum.dot(wf)).real
             return average_exp
         else:


### PR DESCRIPTION
Wavefunction objects were introduced to pyQuil as the default return object
after a `qvm.wavefunction` call is made.  Minor adjustments to the algorithms
in Grove were required to incorporate this small change.

Tests, documentation, and getting started notebooks were updated to reflect the
new pyQuil object.