### PR TITLE
simplified inverse qft

### DIFF
--- a/grove/qft/fourier.py
+++ b/grove/qft/fourier.py
@@ -32,28 +32,6 @@ def bit_reversal(qubits):
         p.inst(SWAP(qubits[i], qubits[-i - 1]))
     return p
 
-def _core_qft(qubits, coeff):
-    """
-    Generates the core program to perform the quantum Fourier transform
-    
-    :param qubits: A list of qubit indexes.
-    :param coeff: A modifier for the angle used in rotations (-1 for inverse 
-                  QFT, 1 for QFT)
-    :return: A Quil program to compute the core (inverse) QFT of the qubits.
-    """
-    
-    q = qubits[0]
-    qs = qubits[1:]
-    if 1 == len(qubits):
-        return [H(q)]
-    else:
-        n = 1 + len(qs)
-        cR = []
-        for idx, i in enumerate(xrange(n - 1, 0, -1)):
-            q_idx = qs[idx]
-            angle = math.pi / 2 ** (n - i)
-            cR.append(CPHASE(coeff * angle)(q, q_idx))
-        return _core_qft(qs, coeff) + list(reversed(cR)) + [H(q)]
 
 def qft(qubits):
     """
@@ -64,7 +42,21 @@ def qft(qubits):
     :return: A Quil program to compute the Fourier transform of the qubits.
     """
 
-    p = pq.Program().inst(_core_qft(qubits, 1))
+    def core_qft(qubits):
+        q = qubits[0]
+        qs = qubits[1:]
+        if 1 == len(qubits):
+            return [H(q)]
+        else:
+            n = 1 + len(qs)
+            cR = []
+            for idx, i in enumerate(xrange(n - 1, 0, -1)):
+                q_idx = qs[idx]
+                angle = math.pi / 2 ** (n - i)
+                cR.append(CPHASE(angle)(q, q_idx))
+            return core_qft(qs) + list(reversed(cR)) + [H(q)]
+
+    p = pq.Program().inst(core_qft(qubits))
     return p + bit_reversal(qubits)
 
 
@@ -74,17 +66,11 @@ def inverse_qft(qubits):
     a set of qubits.
 
     :param qubits: A list of qubit indexes.
-    :return: A Quil program to compute the inverse Fourier transform of the 
+    :return: A Quil program to compute the inverse Fourier transform of the
              qubits.
     """
-    
-    qft_result = pq.Program().inst(_core_qft(qubits, -1))
-    qft_result += bit_reversal(qubits)
-    inverse_qft = pq.Program()
-    while len(qft_result.actions) > 0:
-        new_inst = qft_result.actions.pop()[1]
-        inverse_qft.inst(new_inst)
-    return inverse_qft
+
+    return qft(qubits).dagger()
 
 if __name__ == '__main__':
     print qft([0, 1, 2, 3])


### PR DESCRIPTION
Since pyquil 1.1.0 has the ability to dagger a program, the qft/inverse qft module can be simplified

Fails on semaphore right now, since it isn't using 1.1.0 yet