### PR TITLE
Fixed link to hybrid quantum-classical paper

### DIFF
--- a/docs/vqe.rst
+++ b/docs/vqe.rst
@@ -395,7 +395,7 @@ Here are some links to get you started:
 
 - `A Variational Eigenvalue Solver on a Quantum Processor <https://arxiv.org/abs/1304.3061>`_
 
-- `The Theory of Variational Hybrid Quantum-Classical Algorithms <https://arxiv.org/abs/1304.3061>`_
+- `The Theory of Variational Hybrid Quantum-Classical Algorithms <https://arxiv.org/abs/1509.04279>`_
 
 - `Hybrid Quantum-Classical Approach to Correlated Materials <https://arxiv.org/abs/1510.03859>`_
 


### PR DESCRIPTION
The link at bottom of the documentation in the VQE section for "The Theory of Variational Hybrid Quantum-Classical Algorithms" points to the same link as the paper above it, "A variational eigenvalue solver on a quantum processor". I replaced that link with the appropriate one.