### PR TITLE
Modify qubit ordering convention used throughout Simon's Algorithm

### DIFF
--- a/grove/simon/simon.py
+++ b/grove/simon/simon.py
@@ -151,7 +151,9 @@ def oracle_function(unitary_funct, qubits, ancillas, gate_name='FUNCT'):
 
     inverse_gate_name = gate_name + '-INV'
     scratch_bit = p.alloc()
-    bits_for_funct = [scratch_bit] + qubits
+
+    # qubits order reversal necessary due to defgate convention
+    bits_for_funct = [scratch_bit] + qubits[::-1]
 
     p.defgate(gate_name, unitary_funct)
     p.defgate(inverse_gate_name, np.linalg.inv(unitary_funct))
@@ -381,7 +383,8 @@ def find_mask(cxn, oracle, qubits):
 
     s = binary_back_substitute(W, s)
 
-    s_str = ''.join(str(x) for x in s)
+    # s goes in order from qubit 0 to qubit n-1, thus requiring a reversal
+    s_str = ''.join(str(x) for x in s)[::-1]
 
     return s_str, iterations, simon_program
 
@@ -407,7 +410,7 @@ def check_two_to_one(cxn, oracle, ancillas, s):
     zero_program = oracle
     mask_program = pq.Program()
     for i in xrange(len(s)):
-        if s[i] == '1':
+        if s[-1 - i] == '1':
             mask_program.inst(X(i))
     mask_program += oracle
 


### PR DESCRIPTION
Slight modifications were made to apply the defgate to the expected order of qubits. This also results in a need to refactor the ordering for the mask that is found. While this doesn't change the overall algorithm, it does make intermediate states' interpretation more natural, i.e. lower qubit indices correspond to lower ordered bits as is the convention in pyquil's wavefunction.