### PR TITLE
Adding pyquil as a dependency to build the docs

### DIFF
--- a/docs/rtfd-requirements.txt
+++ b/docs/rtfd-requirements.txt
@@ -1,1 +1,2 @@
 quantum-grove
+pyquil


### PR DESCRIPTION
Fixes #55 

[Fixed docs](http://grove-docs.readthedocs.io/en/pyquil-doc-dep/grover.html#source-code-docs)
