### PR TITLE
Moar grover

### DIFF
--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -20,7 +20,6 @@ import numpy as np
 import pyquil.quil as pq
 from pyquil.gates import H
 from pyquil.quilbase import Qubit
-from pyquil.api import JobConnection
 
 from grove.amplification.amplification import amplification_circuit
 

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -7,7 +7,7 @@
 #
 #        http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable lzaw or agreed to in writing, software
+#    Unless required by applicable law or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -101,7 +101,6 @@ class Grover(object):
         :rtype: str
         """
         self._init_attr(bitstring_map)
-        print self.grover_circuit
         sampled_bitstring = np.array(cxn.run_and_measure(self.grover_circuit, self.qubits),
                                      dtype=int)
         return sampled_bitstring

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -76,7 +76,6 @@ class Grover(object):
         self.bit_map = bitstring_map
         self.unitary_function_mapping = self._compute_grover_oracle_matrix(bitstring_map)
         self.n_qubits = self.unitary_function_mapping.shape[0]
-        print self.unitary_function_mapping
         self.qubits = list(range(int(np.log2(self.n_qubits))))
         self._construct_grover_circuit()
 

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -7,7 +7,7 @@
 #
 #        http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable law or agreed to in writing, software
+#    Unless required by applicable lzaw or agreed to in writing, software
 #    distributed under the License is distributed on an "AS IS" BASIS,
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
@@ -26,7 +26,10 @@ from grove.amplification.amplification import amplification_circuit
 
 
 class Grover(object):
-    """This class contains an implementation of Grover's algorithm using pyQuil. For a reference
+    """This class contains an implementation of Grover's algorithm using pyQuil. See `these notes`_
+     by Dave Bacon for more information.
+
+    .. _these notes: https://courses.cs.washington.edu/courses/cse599d/06wi/lecturenotes12.pdf
     """
     def __init__(self):
         self.unitary_function_mapping = None
@@ -39,8 +42,9 @@ class Grover(object):
     def _compute_grover_oracle_matrix(bitstring_map):
         """Computes the unitary matrix that encodes the oracle function for Grover's algorithm
 
-        :param dict bitstring_map: dict with string keys corresponding to bitstrings, and integer
-         values corresponding to the desired phase on the output state.
+        :param bitstring_map: dict with string keys corresponding to bitstrings,
+         and integer values corresponding to the desired phase on the output state.
+        :type bitstring_map: dict[str, int]
         :return: a numpy array corresponding to the unitary matrix for oracle for the given
          bitstring_map
         :rtype: numpy.ndarray
@@ -68,8 +72,9 @@ class Grover(object):
     def _init_attr(self, bitstring_map):
         """Initializes an instance of Grover's Algorithm given a bitstring_map.
 
-        :param dict bitstring_map: dict with string keys corresponding to bitstrings, and integer
+        :param bitstring_map: dict with string keys corresponding to bitstrings, and integer
          values corresponding to the desired phase on the output state.
+        :type bitstring_map: dict[str, int]
         :return: None
         :rtype: NoneType
         """
@@ -87,12 +92,13 @@ class Grover(object):
         strings, an then use Grover's Algorithm to pick out the desired bitstring.
 
         :param JobConnection cxn: the connection to the Rigetti cloud to run pyQuil programs.
-        :param Dict[String, Int] bitstring_map: a mapping from bitstrings to the phases that the
+        :param bitstring_map: a mapping from bitstrings to the phases that the
          oracle should impart on them. If the oracle should "look" for a bitstring, it should have a
          ``-1``, otherwise it should have a ``1``.
+        :type bitstring_map: dict[str, int]
         :return: Returns the mask of the bitstring map or raises an Exception if the mask cannot be
         found.
-        :rtype: String
+        :rtype: str
         """
         self._init_attr(bitstring_map)
         print self.grover_circuit
@@ -102,11 +108,10 @@ class Grover(object):
 
     @staticmethod
     def oracle_grover(oracle, qubits, num_iter=None):
-        """Implementation of Grover's Algorithm for a given oracle. The query qubit will be left in
-         the zero state afterwards.
+        """Implementation of Grover's Algorithm for a given oracle.
 
         :param Program oracle: An oracle defined as a Program. It should send |x> to (-1)^f(x)|x>,
-                               where the range of f is {0, 1}.
+         where the range of f is {0, 1}.
         :param qubits: List of qubits for Grover's Algorithm.
         :type qubits: list[int or Qubit]
         :param int num_iter: The number of iterations to repeat the algorithm for.
@@ -117,7 +122,6 @@ class Grover(object):
         """
         if num_iter is None:
             num_iter = int(round(np.pi * 2 ** (len(qubits) / 2.0 - 2.0)))
-
         uniform_superimposer = pq.Program().inst([H(qubit) for qubit in qubits])
         amp_prog = amplification_circuit(uniform_superimposer, oracle, qubits, num_iter)
         return amp_prog

--- a/grove/amplification/grover.py
+++ b/grove/amplification/grover.py
@@ -43,7 +43,7 @@ class Grover(object):
 
         :param bitstring_map: dict with string keys corresponding to bitstrings,
          and integer values corresponding to the desired phase on the output state.
-        :type bitstring_map: dict[str, int]
+        :type bitstring_map: Dict[String, Int]
         :return: a numpy array corresponding to the unitary matrix for oracle for the given
          bitstring_map
         :rtype: numpy.ndarray
@@ -73,7 +73,7 @@ class Grover(object):
 
         :param bitstring_map: dict with string keys corresponding to bitstrings, and integer
          values corresponding to the desired phase on the output state.
-        :type bitstring_map: dict[str, int]
+        :type bitstring_map: Dict[String, Int]
         :return: None
         :rtype: NoneType
         """
@@ -94,7 +94,7 @@ class Grover(object):
         :param bitstring_map: a mapping from bitstrings to the phases that the
          oracle should impart on them. If the oracle should "look" for a bitstring, it should have a
          ``-1``, otherwise it should have a ``1``.
-        :type bitstring_map: dict[str, int]
+        :type bitstring_map: Dict[String, Int]
         :return: Returns the mask of the bitstring map or raises an Exception if the mask cannot be
         found.
         :rtype: str

--- a/grove/tests/amplification/test_grover.py
+++ b/grove/tests/amplification/test_grover.py
@@ -111,10 +111,16 @@ def test_optimal_grover(x_oracle):
     assert prog_equality(generated_one_iter_grover, one_iter_grover)
 
 
-def test_bitstring_grover():
+def test_find_bistring():
     bitstring_map = {"0": 1, "1": -1}
-    prog = Grover().construct_grover_program(bitstring_map)
+    builder = Grover()
+    with patch("pyquil.api.SyncConnection") as qvm:
+        expected_bitstring = np.asarray([0, 1], dtype=int)
+        qvm.run_and_measure.return_value = expected_bitstring
+    bitstring = builder.find_bitstring(qvm, bitstring_map)
+    prog = builder.grover_circuit
     # Make sure it only defines the one ORACLE gate.
     assert len(prog.defined_gates) == 1
     # Make sure that it produces the oracle we expect.
     assert (prog.defined_gates[0].matrix == np.array([[1, 0], [0, -1]])).all()
+    assert (bitstring == expected_bitstring).all()

--- a/grove/tests/utils/test_utility_programs.py
+++ b/grove/tests/utils/test_utility_programs.py
@@ -5,6 +5,7 @@ from grove.tests.utils.utils_for_testing import non_action_insts, prog_len
 from grove.utils.utility_programs import ControlledProgramBuilder
 
 SIGMA_Z = np.array([[1, 0], [0, -1]])
+SIGMA_Z_NAME = "Z"
 
 
 def test_1_qubit_control():
@@ -15,31 +16,34 @@ def test_1_qubit_control():
              .with_controls([control_qubit])
              .with_target(qubit)
              .with_operation(SIGMA_Z)
-             .with_gate_name("Z").build())
+             .with_gate_name(SIGMA_Z_NAME).build())
     # This should be one "CZ" instruction, from control_qubit to qubit.
     assert prog_len(prog) == 1
     prog.synthesize()
     instruction = non_action_insts(prog)[0]
-    assert instruction[1].operator_name == 'C[Z]'
+    assert instruction[1].operator_name == (ControlledProgramBuilder()
+                                            .format_gate_name("C", SIGMA_Z_NAME))
     assert instruction[1].arguments == [control_qubit, qubit]
 
 
 def double_control_test(instructions, target_qubit, control_qubit_one, control_qubit_two):
     """A list of asserts testing the simple case of a double controlled Z gate. Used in the next
      two tests."""
-    assert instructions[0][1].operator_name == 'C[SQRT[Z]]'
+    cpg = ControlledProgramBuilder()
+    sqrt_z = cpg.format_gate_name("SQRT", SIGMA_Z_NAME)
+    assert instructions[0][1].operator_name == (cpg.format_gate_name("C", sqrt_z))
     assert instructions[0][1].arguments == [control_qubit_two, target_qubit]
 
-    assert instructions[1][1].operator_name == 'C[NOT]'
+    assert instructions[1][1].operator_name == cpg.format_gate_name("C", "NOT")
     assert instructions[1][1].arguments == [control_qubit_one, control_qubit_two]
 
-    assert instructions[2][1].operator_name == 'C[SQRT[Z]]-INV'
+    assert instructions[2][1].operator_name == cpg.format_gate_name("C", sqrt_z) + '-INV'
     assert instructions[2][1].arguments == [control_qubit_two, target_qubit]
 
-    assert instructions[3][1].operator_name == 'C[NOT]'
+    assert instructions[3][1].operator_name == cpg.format_gate_name("C", "NOT")
     assert instructions[3][1].arguments == [control_qubit_one, control_qubit_two]
 
-    assert instructions[4][1].operator_name == 'C[SQRT[Z]]'
+    assert instructions[4][1].operator_name == cpg.format_gate_name("C", sqrt_z)
     assert instructions[4][1].arguments == [control_qubit_one, target_qubit]
 
 
@@ -52,7 +56,7 @@ def test_recursive_builder():
            .with_controls([control_qubit_one, control_qubit_two])
            .with_target(target_qubit)
            .with_operation(SIGMA_Z)
-           .with_gate_name("Z"))
+           .with_gate_name(SIGMA_Z_NAME))
     prog = cpg._recursive_builder(cpg.operation,
                                   cpg.gate_name,
                                   cpg.control_qubits,
@@ -72,7 +76,7 @@ def test_2_qubit_control():
              .with_controls([control_qubit_one, control_qubit_two])
              .with_target(qubit)
              .with_operation(SIGMA_Z)
-             .with_gate_name("Z").build())
+             .with_gate_name(SIGMA_Z_NAME).build())
     # This should be one "CZ" instruction, from control_qubit to qubit.
     assert prog_len(prog) == 5
     prog.synthesize()

--- a/grove/utils/utility_programs.py
+++ b/grove/utils/utility_programs.py
@@ -103,7 +103,7 @@ class ControlledProgramBuilder(object):
         :param str gate_name: The gate name to format and extend.
         :return: The formatted gate name.
         """
-        formatted_gate_name = prefix + '[' + gate_name + ']'
+        formatted_gate_name = prefix + '-' + gate_name
         return formatted_gate_name
 
     def build(self):


### PR DESCRIPTION
Fixes #88.
Also note that `[, ]` are not allowed in Quil, so we've changed the autogenerated defgate labels to use dashes.