### PR TITLE
repaired get_string_method in qaoa.py and added unit test

### DIFF
--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -246,7 +246,7 @@ class QAOA(object):
             sampling_prog.measure(i, [i])
 
         bitstring_samples = self.qvm.run_and_measure(sampling_prog,
-                                                     range(self.n_qubits),
+                                                     list(range(self.n_qubits)),
                                                      trials=samples)
         bitstring_tuples = list(map(tuple, bitstring_samples))
         freq = Counter(bitstring_tuples)

--- a/grove/tests/pyqaoa/test_qaoa.py
+++ b/grove/tests/pyqaoa/test_qaoa.py
@@ -67,6 +67,18 @@ def test_get_angles():
         assert gammas == [3.4, 4.3]
 
 
+def test_get_string():
+    qvm = qvm_module.SyncConnection()
+    qaoa = QAOA(qvm, n_qubits=1)
+    prog = Program()
+    prog.inst(X(0))
+    qaoa.get_parameterized_program = lambda: lambda angles: prog
+    samples = 10
+    bitstring, freq = qaoa.get_string(betas=None, gammas=None, samples=samples)
+    assert len(freq) <= samples
+    assert bitstring[0] == 1
+
+
 def test_ref_program_pass():
     ref_prog = Program().inst([X(0), Y(1), Z(2)])
     fakeQVM = Mock(spec=qvm_module.SyncConnection())


### PR DESCRIPTION
@jotterbach I confirmed that the unittest passes for both python 2.7 and 3.6 and also that maxcut_qaoa.py runs for both 2.7 and 3.6 .