### PR TITLE
Change the second QAOA argument to a list of qubits rather than a count

### DIFF
--- a/grove/pyqaoa/maxcut_qaoa.py
+++ b/grove/pyqaoa/maxcut_qaoa.py
@@ -75,7 +75,7 @@ def maxcut_qaoa(graph, steps=1, rand_seed=None, connection=None, samples=None,
         vqe_option = {'disp': print_fun, 'return_all': True,
                       'samples': samples}
 
-    qaoa_inst = QAOA(connection, len(graph.nodes()), steps=steps, cost_ham=cost_operators,
+    qaoa_inst = QAOA(connection, list(graph.nodes()), steps=steps, cost_ham=cost_operators,
                      ref_hamiltonian=driver_operators, store_basis=True,
                      rand_seed=rand_seed,
                      init_betas=initial_beta,

--- a/grove/pyqaoa/numpartition_qaoa.py
+++ b/grove/pyqaoa/numpartition_qaoa.py
@@ -46,8 +46,8 @@ def numpart_qaoa(asset_list, A=1.0, minimizer_kwargs=None, steps=1):
                             'options': {'ftol': 1.0e-2,
                                         'xtol': 1.0e-2,
                                         'disp': True}}
-    n_qubits = len(asset_list)
-    qaoa_inst = QAOA(CXN, n_qubits, steps=steps, cost_ham=cost_operators,
+                                        
+    qaoa_inst = QAOA(CXN, len(asset_list), steps=steps, cost_ham=cost_operators,
                      ref_hamiltonian=ref_operators, store_basis=True,
                      minimizer=minimize, minimizer_kwargs=minimizer_kwargs,
                      vqe_options={'disp': True})

--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -25,7 +25,7 @@ from functools import reduce
 
 
 class QAOA(object):
-    def __init__(self, qvm, n_qubits, steps=1, init_betas=None,
+    def __init__(self, qvm, qubits, steps=1, init_betas=None,
                  init_gammas=None, cost_ham=[],
                  ref_hamiltonian=[], driver_ref=None,
                  minimizer=None, minimizer_args=[],
@@ -38,7 +38,7 @@ class QAOA(object):
         ground state of the list of cost clauses.
 
         :param qvm: (Connection) The qvm connection to use for the algorithm.
-        :param n_qubits: (int) The number of qubits to use for the algorithm.
+        :param qubits: (list of ints) The number of qubits to use for the algorithm.
         :param steps: (int) The number of mixing and cost function steps to use.
                       Default=1.
         :param init_betas: (list) Initial values for the beta parameters on the
@@ -68,10 +68,10 @@ class QAOA(object):
         """
         self.qvm = qvm
         self.steps = steps
-        self.n_qubits = n_qubits
-        self.nstates = 2 ** n_qubits
+        self.qubits = qubits
+        self.nstates = 2 ** len(qubits)
         if store_basis:
-            self.states = [np.binary_repr(i, width=self.n_qubits) for i in range(
+            self.states = [np.binary_repr(i, width=len(self.qubits)) for i in range(
                            self.nstates)]
         self.betas = init_betas
         self.gammas = init_gammas
@@ -85,7 +85,7 @@ class QAOA(object):
                 self.ref_state_prep = driver_ref
         else:
             ref_prog = pq.Program()
-            for i in range(self.n_qubits):
+            for i in qubits:
                 ref_prog.inst(H(i))
             self.ref_state_prep = ref_prog
 
@@ -217,7 +217,7 @@ class QAOA(object):
         wf, _ = self.qvm.wavefunction(prog)
         wf = wf.amplitudes.reshape((-1, 1))
         probs = np.zeros_like(wf)
-        for xx in range(2 ** self.n_qubits):
+        for xx in range(2 ** len(self.qubits)):
             probs[xx] = np.conj(wf[xx]) * wf[xx]
         return probs
 

--- a/grove/tests/pyqaoa/test_qaoa.py
+++ b/grove/tests/pyqaoa/test_qaoa.py
@@ -37,7 +37,7 @@ def test_probabilities():
                    -1.17642098e-05 - 1j*7.67538040e-06])
     fakeQVM = Mock(spec=qvm_module.SyncConnection())
     fakeQVM.wavefunction = Mock(return_value=(Wavefunction(wf), 0))
-    inst = QAOA(fakeQVM, n_qubits, steps=p,
+    inst = QAOA(fakeQVM, range(n_qubits), steps=p,
                 rand_seed=42)
 
     true_probs = np.zeros_like(wf)
@@ -60,7 +60,7 @@ def test_get_angles():
         result = Mock()
         result.x = [1.2, 2.1, 3.4, 4.3]
         inst.vqe_run.return_value = result
-        MCinst = QAOA(fakeQVM, n_qubits, steps=p,
+        MCinst = QAOA(fakeQVM, range(n_qubits), steps=p,
                       cost_ham=[PauliSum([PauliTerm("X", 0)])])
         betas, gammas = MCinst.get_angles()
         assert betas == [1.2, 2.1]
@@ -70,7 +70,7 @@ def test_get_angles():
 def test_ref_program_pass():
     ref_prog = Program().inst([X(0), Y(1), Z(2)])
     fakeQVM = Mock(spec=qvm_module.SyncConnection())
-    inst = QAOA(fakeQVM, 2, driver_ref=ref_prog)
+    inst = QAOA(fakeQVM, range(2), driver_ref=ref_prog)
     param_prog = inst.get_parameterized_program()
     test_prog = param_prog([0, 0])
     compare_progs(ref_prog, test_prog)


### PR DESCRIPTION
Affects the initialization procedure, where range(n_qubits) was used to apply a bunch of Hadamards, even if the driver hamiltonian terms had nothing to do with this initial segment of qubits. This was affecting QPU usage.

Fixes #126.