### PR TITLE
Use asynchronous run instead of synchronous run_and_measure for tomography

### DIFF
--- a/examples/Tomography.ipynb
+++ b/examples/Tomography.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "\n",
     "from pyquil.gates import CZ, RY\n",
-    "from pyquil.api import QVMConnection, QPUConnection, get_devices\n",
+    "from pyquil.api import QVMConnection, QPUConnection, get_devices, Job\n",
     "from pyquil.quil import Program\n",
     "\n",
     "try:\n",
@@ -62,9 +62,13 @@
     "        print(\"Could not find online device, defaulting to QVM\")\n",
     "else:\n",
     "    qvm = MagicMock(QVMConnection)\n",
-    "    qvm.run_and_measure.side_effect = json.load(open(\"qvm.json\", 'r'))\n",
+    "    qvm_job = MagicMock(Job)\n",
+    "    qvm.wait_for_job.return_value = qvm_job\n",
+    "    qvm_job.result.side_effect = json.load(open(\"qvm.json\", 'r'))\n",
     "    qpu = MagicMock(QPUConnection)\n",
-    "    qpu.run_and_measure.side_effect = json.load(open(\"qpu.json\", 'r'))"
+    "    qpu_job = MagicMock(Job)\n",
+    "    qpu.wait_for_job.return_value = qpu_job\n",
+    "    qpu_job.result.side_effect = json.load(open(\"qpu.json\", 'r'))"
    ]
   },
   {

--- a/grove/tests/tomography/test_process_tomography.py
+++ b/grove/tests/tomography/test_process_tomography.py
@@ -51,6 +51,8 @@ RESULTS_PATH = os.path.join(os.path.dirname(__file__), 'process_results.json')
 sample_bad_readout = MagicMock(sample_bad_readout)
 sample_bad_readout.side_effect = [np.array(shots) for shots in json.load(open(SHOTS_PATH, 'r'))]
 
+# these mocks are set up such that a single mock Job is returned by the QVMConnection's wait_for_job
+# but calling job.result() returns a different value every time via the side_effect defined below
 cxn = MagicMock(QVMConnection)
 job = MagicMock(Job)
 job.result.side_effect = json.load(open(RESULTS_PATH, 'r'))

--- a/grove/tests/tomography/test_process_tomography.py
+++ b/grove/tests/tomography/test_process_tomography.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 ##############################################################################
 
-import matplotlib
 import pytest
 import os
 import numpy as np
@@ -22,7 +21,7 @@ from mock import patch
 from mock import MagicMock, Mock
 import json
 
-from pyquil.api import QVMConnection
+from pyquil.api import Job, QVMConnection
 
 from grove.tomography.tomography import (MAX_QUBITS_PROCESS_TOMO,
                                          default_channel_ops)
@@ -53,7 +52,9 @@ sample_bad_readout = MagicMock(sample_bad_readout)
 sample_bad_readout.side_effect = [np.array(shots) for shots in json.load(open(SHOTS_PATH, 'r'))]
 
 cxn = MagicMock(QVMConnection)
-cxn.run_and_measure.side_effect = json.load(open(RESULTS_PATH, 'r'))
+job = MagicMock(Job)
+job.result.side_effect = json.load(open(RESULTS_PATH, 'r'))
+cxn.wait_for_job.return_value = job
 
 
 def test_process_tomography():

--- a/grove/tests/tomography/test_state_tomography.py
+++ b/grove/tests/tomography/test_state_tomography.py
@@ -54,6 +54,8 @@ RESULTS_PATH = os.path.join(os.path.dirname(__file__), 'state_results.json')
 sample_bad_readout = MagicMock(sample_bad_readout)
 sample_bad_readout.side_effect = [np.array(shots) for shots in json.load(open(SHOTS_PATH, 'r'))]
 
+# these mocks are set up such that a single mock Job is returned by the QVMConnection's wait_for_job
+# but calling job.result() returns a different value every time via the side_effect defined below
 cxn = MagicMock(QVMConnection)
 job = MagicMock(Job)
 job.result.side_effect = json.load(open(RESULTS_PATH, 'r'))

--- a/grove/tests/tomography/test_state_tomography.py
+++ b/grove/tests/tomography/test_state_tomography.py
@@ -22,7 +22,7 @@ import pytest
 
 from mock import MagicMock
 from mock import patch
-from pyquil.api import QVMConnection
+from pyquil.api import Job, QVMConnection
 
 from grove.tomography.operator_utils import make_diagonal_povm
 from grove.tomography.process_tomography import (TRACE_PRESERVING)
@@ -55,7 +55,9 @@ sample_bad_readout = MagicMock(sample_bad_readout)
 sample_bad_readout.side_effect = [np.array(shots) for shots in json.load(open(SHOTS_PATH, 'r'))]
 
 cxn = MagicMock(QVMConnection)
-cxn.run_and_measure.side_effect = json.load(open(RESULTS_PATH, 'r'))
+job = MagicMock(Job)
+job.result.side_effect = json.load(open(RESULTS_PATH, 'r'))
+cxn.wait_for_job.return_value = job
 
 
 def test_state_tomography():


### PR DESCRIPTION
* Improves running time
* Promotes QVM/QPU equivalence