### PR TITLE
Enable the usage of run instead of run_and_measure in tomography

### DIFF
--- a/grove/tests/tomography/test_state_tomography.py
+++ b/grove/tests/tomography/test_state_tomography.py
@@ -58,7 +58,8 @@ sample_bad_readout.side_effect = [np.array(shots) for shots in json.load(open(SH
 # but calling job.result() returns a different value every time via the side_effect defined below
 cxn = MagicMock(QVMConnection)
 job = MagicMock(Job)
-job.result.side_effect = json.load(open(RESULTS_PATH, 'r'))
+# repeat twice for run_and_measure and run
+job.result.side_effect = json.load(open(RESULTS_PATH, 'r')) * 2
 cxn.wait_for_job.return_value = job
 
 
@@ -110,3 +111,9 @@ def test_do_state_tomography():
         assert np.sum(histogram) == nsamples
     num_qubits = len(BELL_STATE_PROGRAM.get_qubits())
     assert np.isclose(assignment_probs, np.eye(2 ** num_qubits), atol=EPS).all()
+
+    # ensure that use_run works.
+    state_tomo2, _, _ = do_state_tomography(BELL_STATE_PROGRAM, nsamples, cxn, use_run=True)
+    assert np.allclose(state_tomo2.rho_est.data.toarray(), state_tomo.rho_est.data.toarray(),
+                       atol=1e-3)
+

--- a/grove/tomography/process_tomography.py
+++ b/grove/tomography/process_tomography.py
@@ -302,7 +302,7 @@ def process_tomography_programs(process, qubits=None,
             yield process_tomography_program
 
 
-def do_process_tomography(process, nsamples, cxn, qubits=None):
+def do_process_tomography(process, nsamples, cxn, qubits=None, use_run=False):
     """
     Method to perform a process tomography.
 
@@ -311,10 +311,12 @@ def do_process_tomography(process, nsamples, cxn, qubits=None):
     :param QVMConnection|QPUConnection cxn: Connection on which to run the program.
     :param list qubits: List of qubits for the program.
     to use in the tomography analysis.
+    :param bool use_run: If ``True``, use append measurements on all qubits and use ``cxn.run``
+        instead of ``cxn.run_and_measure``.
     :return: The process tomogram
     :rtype: ProcessTomography
     """
     return tomography._do_tomography(process, nsamples, cxn, qubits,
                                      tomography.MAX_QUBITS_PROCESS_TOMO,
                                      ProcessTomography, process_tomography_programs,
-                                     DEFAULT_PROCESS_TOMO_SETTINGS)
+                                     DEFAULT_PROCESS_TOMO_SETTINGS, use_run=use_run)

--- a/grove/tomography/state_tomography.py
+++ b/grove/tomography/state_tomography.py
@@ -244,7 +244,7 @@ def state_tomography_programs(state_prep, qubits=None,
         yield state_tomography_program
 
 
-def do_state_tomography(preparation_program, nsamples, cxn, qubits=None):
+def do_state_tomography(preparation_program, nsamples, cxn, qubits=None, use_run=False):
     """
     Method to perform both a QPU and QVM state tomography, and use the latter as
     as reference to calculate the fidelity of the former.
@@ -254,10 +254,12 @@ def do_state_tomography(preparation_program, nsamples, cxn, qubits=None):
     :param QVMConnection|QPUConnection cxn: Connection on which to run the program.
     :param list qubits: List of qubits for the program.
     to use in the tomography analysis.
+    :param bool use_run: If ``True``, use append measurements on all qubits and use ``cxn.run``
+        instead of ``cxn.run_and_measure``.
     :return: The state tomogram.
     :rtype: StateTomography
     """
     return tomography._do_tomography(preparation_program, nsamples, cxn, qubits,
                                      tomography.MAX_QUBITS_STATE_TOMO,
                                      StateTomography, state_tomography_programs,
-                                     DEFAULT_STATE_TOMO_SETTINGS)
+                                     DEFAULT_STATE_TOMO_SETTINGS, use_run=use_run)


### PR DESCRIPTION
This allows to use `run` instead of `run_and_measure` for tomography. For the QPU there is no difference, but on the QVM this allows simulating noisy tomography.