### PR TITLE
QAOA: removed measure command from quil program in get_string.

### DIFF
--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -242,8 +242,6 @@ class QAOA(object):
         param_prog = self.get_parameterized_program()
         stacked_params = np.hstack((betas, gammas))
         sampling_prog = param_prog(stacked_params)
-        for i in range(self.n_qubits):
-            sampling_prog.measure(i, [i])
 
         bitstring_samples = self.qvm.run_and_measure(sampling_prog,
                                                      list(range(self.n_qubits)),


### PR DESCRIPTION
While using get_string() method in qaoa I observed, that it always returns only one string, but probabilities() gave pretty similar probabilities to all the results.

It seems to me, that measuring qubits collapsed all of them into one state and all the subsequent measurements gave the same results.