### PR TITLE
Swap test for testing state overlaps

### DIFF
--- a/grove/circuit_primitives/__init__.py
+++ b/grove/circuit_primitives/__init__.py
@@ -1,0 +1,3 @@
+"""
+Circuit primitives & useful small scale algorithms
+"""

--- a/grove/circuit_primitives/swap.py
+++ b/grove/circuit_primitives/swap.py
@@ -1,0 +1,85 @@
+"""
+Implementation of the swap test
+
+Given two states existing on registers A and B, their overlap can be measured
+by performing a swap test.
+"""
+import numpy as np
+from pyquil.quil import Program
+from pyquil.gates import H, CSWAP
+
+
+class RegisterSizeMismatch(Exception):
+    """Error associated with mismatch register size"""
+    pass
+
+
+def swap_circuit_generator(register_a, register_b, ancilla):
+    """
+    Generate the swap test circuit primitive.
+
+    Registers A and B must be of equivalent size for swap to work.  This module
+    uses the CSWAP gate in pyquil.
+
+    :param List register_a: qubit labels in the 'A' register
+    :param List register_b: qubit labels in the 'B' register
+    :param ancilla: ancilla to measure and control of swap operation.
+    :return: Program
+    """
+    if len(register_a) != len(register_b):
+        raise RegisterSizeMismatch("registers involve different numbers of qubits")
+
+    if not isinstance(register_a, list):
+        raise TypeError("Register A need to be list")
+    if not isinstance(register_b, list):
+        raise TypeError("Register B needs to be a list")
+
+    if ancilla is None:
+        ancilla = max(register_a + register_b) + 1
+
+    swap_program = Program()
+    swap_program += H(ancilla)
+    for a, b in zip(register_a, register_b):
+        swap_program += CSWAP(ancilla, a, b)
+    swap_program += H(ancilla)
+
+    return swap_program
+
+
+def run_swap_test(program_a, program_b, number_of_measurements, quantum_resource,
+                  classical_memory=0, ancilla=None):
+    """
+    Run a swap test and return the calculated overlap
+
+    :param Program program_a: state preparation for the 'A' register
+    :param Program program_b: state preparation for the 'B' register
+    :param Int number_of_measurements: number of times to measure
+    :param quantum_resource: QAM connection object
+    :param Int classical_memory: location of classical memory slot to use
+    :param ancilla: Index of ancilla
+    :return: overlap of states prepared by program_a and program_b
+    :rtype: float
+    """
+    register_a = list(program_a.get_qubits())
+    register_b = list(program_b.get_qubits())
+    if ancilla is None:
+        ancilla = max(register_a + register_b) + 1
+
+    swap_test_program = Program()
+    swap_test_program += program_a + program_b
+    swap_test_program += swap_circuit_generator(register_a, register_b, ancilla)
+    swap_test_program.measure(ancilla, [classical_memory])
+
+    # TODO: instead of number of measurements have user set precision of overlap
+    # estimate and calculate number of shots to be within this precision
+    results = quantum_resource.run(swap_test_program,
+                                   classical_memory,
+                                   trials=number_of_measurements)
+
+    estimated_overlap = np.sqrt(2 * np.mean(results) - 1)
+    return estimated_overlap
+
+
+
+
+

--- a/grove/circuit_primitives/swap.py
+++ b/grove/circuit_primitives/swap.py
@@ -10,7 +10,7 @@ from pyquil.gates import H, CSWAP
 
 
 class RegisterSizeMismatch(Exception):
-    """Error associated with mismatch register size"""
+    """Error associated with mismatched register size"""
     pass
 
 
@@ -23,14 +23,14 @@ def swap_circuit_generator(register_a, register_b, ancilla):
 
     :param List register_a: qubit labels in the 'A' register
     :param List register_b: qubit labels in the 'B' register
-    :param ancilla: ancilla to measure and control of swap operation.
+    :param ancilla: ancilla to measure and control the swap operation.
     :return: Program
     """
     if len(register_a) != len(register_b):
         raise RegisterSizeMismatch("registers involve different numbers of qubits")
 
     if not isinstance(register_a, list):
-        raise TypeError("Register A need to be list")
+        raise TypeError("Register A needs to be list")
     if not isinstance(register_b, list):
         raise TypeError("Register B needs to be a list")
 
@@ -76,7 +76,11 @@ def run_swap_test(program_a, program_b, number_of_measurements, quantum_resource
                                    classical_memory,
                                    trials=number_of_measurements)
 
-    estimated_overlap = np.sqrt(2 * np.mean(results) - 1)
+    probability_of_one = np.mean(results)
+    if probability_of_one > 0.5:
+        raise ValueError("measurements indicate overlap is negative")
+
+    estimated_overlap = np.sqrt(1 - 2 * probability_of_one)
     return estimated_overlap
 
 

--- a/grove/tests/circuit_primitives/test_swap.py
+++ b/grove/tests/circuit_primitives/test_swap.py
@@ -51,12 +51,21 @@ def test_run_swap():
     """
     Test the qvm return piece
     """
-    expected_bitstring = [1, 1, 1, 0, 1]
+    expected_bitstring = [1, 1, 1, 0, 0, 0, 0, 0, 0]
     prog_a = Program().inst(H(0))
     prog_b = Program().inst(H(1))
     with patch("pyquil.api.QVMConnection") as qvm:
         qvm.run.return_value = expected_bitstring
         test_overlap = run_swap_test(prog_a, prog_b, 5, qvm)
 
-        assert np.isclose(np.sqrt(2 * np.mean(expected_bitstring) - 1),
+        assert np.isclose(np.sqrt(1 - 2 * np.mean(expected_bitstring)),
                           test_overlap)
+
+    expected_bitstring = [1, 1, 1, 0, 1]
+    prog_a = Program().inst(H(0))
+    prog_b = Program().inst(H(1))
+    with patch("pyquil.api.QVMConnection") as qvm:
+        qvm.run.return_value = expected_bitstring
+        with pytest.raises(ValueError):
+            test_overlap = run_swap_test(prog_a, prog_b, 5, qvm)
+

--- a/grove/tests/circuit_primitives/test_swap.py
+++ b/grove/tests/circuit_primitives/test_swap.py
@@ -1,0 +1,62 @@
+"""
+Tests on the swap test in the circuit_primitives module
+"""
+import pytest
+from mock import patch
+import numpy as np
+from pyquil.quil import Program
+from pyquil.gates import CSWAP, H
+from grove.circuit_primitives.swap import (swap_circuit_generator,
+                                           run_swap_test,  RegisterSizeMismatch)
+
+def test_swap_circuit_gen_type():
+    """
+    Test the type checking
+    """
+    with pytest.raises(TypeError):
+        swap_circuit_generator(5, [1, 2], 0)
+
+    with pytest.raises(TypeError):
+        swap_circuit_generator([1, 2], 5, 0)
+
+    with pytest.raises(RegisterSizeMismatch):
+        swap_circuit_generator([1, 2], [3], 0)
+
+
+def test_default_ancilla_assignment():
+    """
+    Make sure ancilla is assigned to max(regA + regB) + 1 by default
+    :return:
+    """
+    test_prog_for_ancilla = swap_circuit_generator([1, 2], [5, 6], None)
+    instruction = test_prog_for_ancilla.pop()
+    assert instruction.qubits[0].index == 7
+
+
+def test_cswap_program():
+    """
+    Test if the correct program is returned.  Half way to system test
+    """
+    test_prog = swap_circuit_generator([1, 2], [5, 6], None)
+    true_prog = Program()
+    true_prog += H(7)
+    true_prog += CSWAP(7, 1, 5)
+    true_prog += CSWAP(7, 2, 6)
+    true_prog += H(7)
+
+    assert test_prog.out() == true_prog.out()
+
+
+def test_run_swap():
+    """
+    Test the qvm return piece
+    """
+    expected_bitstring = [1, 1, 1, 0, 1]
+    prog_a = Program().inst(H(0))
+    prog_b = Program().inst(H(1))
+    with patch("pyquil.api.QVMConnection") as qvm:
+        qvm.run.return_value = expected_bitstring
+        test_overlap = run_swap_test(prog_a, prog_b, 5, qvm)
+
+        assert np.isclose(np.sqrt(2 * np.mean(expected_bitstring) - 1),
+                          test_overlap)


### PR DESCRIPTION
Naive, uncompiled, swap test using standard gates in pyquil.

Updates should involve 1) removal of number of shots in exchange for a
confidence interval the user is willing to tolerate 2) A compiled
version of CSWAP for Rigetti's hardware.