### PR TITLE
Do not use mutable types in QAOA initialization

### DIFF
--- a/grove/ising/ising_qaoa.py
+++ b/grove/ising/ising_qaoa.py
@@ -110,7 +110,7 @@ def ising(h, J, num_steps=0, verbose=True, rand_seed=None, connection=None, samp
         vqe_option['disp'] = None
 
     qaoa_inst = QAOA(connection, range(n_nodes), steps=num_steps, cost_ham=cost_operators,
-                     ref_hamiltonian=driver_operators, store_basis=True,
+                     ref_ham=driver_operators, store_basis=True,
                      rand_seed=rand_seed,
                      init_betas=initial_beta,
                      init_gammas=initial_gamma,

--- a/grove/pyqaoa/getting-started/QAOA_overview_maxcut.ipynb
+++ b/grove/pyqaoa/getting-started/QAOA_overview_maxcut.ipynb
@@ -272,7 +272,7 @@
    },
    "outputs": [],
    "source": [
-    "ring_cut_inst = QAOA(CXN, len(graph.nodes()), steps=1, ref_hamiltonian=driver_operators, cost_ham=cost_operators,\n",
+    "ring_cut_inst = QAOA(CXN, len(graph.nodes()), steps=1, ref_ham=driver_operators, cost_ham=cost_operators,\n",
     "                     driver_ref=prog, store_basis=True, rand_seed=42)"
    ]
   },
@@ -390,7 +390,7 @@
     "betas = np.hstack((beta[0]/3, beta[0]*2/3))\n",
     "gammas = np.hstack((gamma[0]/3, gamma[0]*2/3))\n",
     "# set up a new QAOA instance.\n",
-    "ring_cut_inst_2 = QAOA(CXN, len(graph.nodes()), steps=2, ref_hamiltonian=driver_operators, cost_ham=cost_operators,\n",
+    "ring_cut_inst_2 = QAOA(CXN, len(graph.nodes()), steps=2, ref_ham=driver_operators, cost_ham=cost_operators,\n",
     "                     driver_ref=prog, store_basis=True, init_betas=betas, init_gammas=gammas)\n",
     "# run VQE to determine the optimal angles\n",
     "betas, gammas = ring_cut_inst_2.get_angles()\n",
@@ -416,7 +416,7 @@
    "source": [
     "from scipy.optimize import fmin_bfgs\n",
     "\n",
-    "ring_cut_inst_3 = QAOA(CXN, len(graph.nodes()), steps=3, ref_hamiltonian=driver_operators, cost_ham=cost_operators,\n",
+    "ring_cut_inst_3 = QAOA(CXN, len(graph.nodes()), steps=3, ref_ham=driver_operators, cost_ham=cost_operators,\n",
     "                       driver_ref=prog, store_basis=True, minimizer=fmin_bfgs, minimizer_kwargs={'gtol':1.0e-3},\n",
     "                       rand_seed=42)\n",
     "betas, gammas = ring_cut_inst_3.get_angles()\n",

--- a/grove/pyqaoa/maxcut_qaoa.py
+++ b/grove/pyqaoa/maxcut_qaoa.py
@@ -76,7 +76,7 @@ def maxcut_qaoa(graph, steps=1, rand_seed=None, connection=None, samples=None,
                       'samples': samples}
 
     qaoa_inst = QAOA(connection, list(graph.nodes()), steps=steps, cost_ham=cost_operators,
-                     ref_hamiltonian=driver_operators, store_basis=True,
+                     ref_ham=driver_operators, store_basis=True,
                      rand_seed=rand_seed,
                      init_betas=initial_beta,
                      init_gammas=initial_gamma,

--- a/grove/pyqaoa/numpartition_qaoa.py
+++ b/grove/pyqaoa/numpartition_qaoa.py
@@ -46,9 +46,9 @@ def numpart_qaoa(asset_list, A=1.0, minimizer_kwargs=None, steps=1):
                             'options': {'ftol': 1.0e-2,
                                         'xtol': 1.0e-2,
                                         'disp': True}}
-                                        
+
     qaoa_inst = QAOA(CXN, len(asset_list), steps=steps, cost_ham=cost_operators,
-                     ref_hamiltonian=ref_operators, store_basis=True,
+                     ref_ham=ref_operators, store_basis=True,
                      minimizer=minimize, minimizer_kwargs=minimizer_kwargs,
                      vqe_options={'disp': True})
 

--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -27,7 +27,7 @@ from functools import reduce
 class QAOA(object):
     def __init__(self, qvm, qubits, steps=1, init_betas=None,
                  init_gammas=None, cost_ham=[],
-                 ref_hamiltonian=[], driver_ref=None,
+                 ref_ham=[], driver_ref=None,
                  minimizer=None, minimizer_args=[],
                  minimizer_kwargs={}, rand_seed=None,
                  vqe_options={}, store_basis=False):
@@ -47,7 +47,7 @@ class QAOA(object):
                             cost function. Default=None.
         :param cost_ham: list of clauses in the cost function. Must be
                     PauliSum objects
-        :param ref_hamiltonian: list of clauses in the cost function. Must be
+        :param ref_ham: list of clauses in the mixer function. Must be
                     PauliSum objects
         :param driver_ref: (pyQuil.quil.Program()) object to define state prep
                            for the starting state of the QAOA algorithm.
@@ -79,8 +79,8 @@ class QAOA(object):
 
         if driver_ref is not None:
             if not isinstance(driver_ref, pq.Program):
-                raise TypeError("""Please provide a pyQuil Program object as a
-                                   to generate initial state""")
+                raise TypeError("Please provide a pyQuil Program object "
+                                   "to generate initial state.")
             else:
                 self.ref_state_prep = driver_ref
         else:
@@ -90,22 +90,22 @@ class QAOA(object):
             self.ref_state_prep = ref_prog
 
         if not isinstance(cost_ham, (list, tuple)):
-            raise TypeError("""cost_hamiltonian must be a list of PauliSum
-                               objects""")
+            raise TypeError("cost_hamiltonian must be a list of PauliSum "
+                               "objects.")
         if not all([isinstance(x, PauliSum) for x in cost_ham]):
-            raise TypeError("""cost_hamiltonian must be a list of PauliSum
-                                   objects""")
+            raise TypeError("cost_hamiltonian must be a list of PauliSum "
+                                   "objects")
         else:
             self.cost_ham = cost_ham
 
-        if not isinstance(ref_hamiltonian, (list, tuple)):
-            raise TypeError("""cost_hamiltonian must be a list of PauliSum
-                               objects""")
-        if not all([isinstance(x, PauliSum) for x in ref_hamiltonian]):
-            raise TypeError("""cost_hamiltonian must be a list of PauliSum
-                                   objects""")
+        if not isinstance(ref_ham, (list, tuple)):
+            raise TypeError("cost_hamiltonian must be a list of PauliSum "
+                               "objects")
+        if not all([isinstance(x, PauliSum) for x in ref_ham]):
+            raise TypeError("cost_hamiltonian must be a list of PauliSum "
+                                   "objects")
         else:
-            self.ref_ham = ref_hamiltonian
+            self.ref_ham = ref_ham
 
         if minimizer is None:
             self.minimizer = optimize.minimize
@@ -154,14 +154,15 @@ class QAOA(object):
             driver_para_programs.append(driver_list)
 
         def psi_ref(params):
-            """Construct a Quil program for the vector (beta, gamma).
+            """
+            Construct a Quil program for the vector (beta, gamma).
 
             :param params: array of 2 . p angles, betas first, then gammas
             :return: a pyquil program object
             """
             if len(params) != 2*self.steps:
-                raise ValueError("""params doesn't match the number of parameters set
-                                    by `steps`""")
+                raise ValueError("params doesn't match the number of parameters set "
+                                    "by `steps`")
             betas = params[:self.steps]
             gammas = params[self.steps:]
 

--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -115,7 +115,7 @@ class QAOA(object):
         if not isinstance(self.ref_ham, (list, tuple)):
             raise TypeError("ref_ham must be a list of PauliSum objects")
         if not all([isinstance(x, PauliSum) for x in self.ref_ham]):
-            raise TypeError("cost_ham must be a list of PauliSum objects")
+            raise TypeError("ref_ham must be a list of PauliSum objects")
 
         if not isinstance(self.ref_state_prep, pq.Program):
             raise TypeError("Please provide a pyQuil Program object "

--- a/grove/pyqaoa/qaoa.py
+++ b/grove/pyqaoa/qaoa.py
@@ -67,7 +67,7 @@ class QAOA(object):
                             Default=False.
         """
 
-        # Randomize seed
+        # Seed the random number generator, if a seed is provided.
         if rand_seed is not None:
             np.random.seed(rand_seed)
 
@@ -97,7 +97,7 @@ class QAOA(object):
 
         self.ref_state_prep = (
             driver_ref or
-            pq.Program(*[H(i) for i in self.qubits])
+            pq.Program([H(i) for i in self.qubits])
         )
 
         if store_basis:
@@ -153,8 +153,7 @@ class QAOA(object):
             :return: a pyquil program object
             """
             if len(params) != 2*self.steps:
-                raise ValueError("params doesn't match the number of parameters set "
-                                    "by `steps`")
+                raise ValueError("params doesn't match the number of parameters set by `steps`")
             betas = params[:self.steps]
             gammas = params[self.steps:]
 

--- a/grove/tests/pyqaoa/test_maxcut.py
+++ b/grove/tests/pyqaoa/test_maxcut.py
@@ -32,7 +32,7 @@ def test_pass_hamiltonians():
                 PauliTerm("Z", 1, 1.0)]
     fakeQVM = Mock()
     inst = QAOA(fakeQVM, range(2), steps=1,
-                cost_ham=cost_ham, ref_hamiltonian=ref_ham)
+                cost_ham=cost_ham, ref_ham=ref_ham)
 
     c = inst.cost_ham
     r = inst.ref_ham
@@ -45,7 +45,7 @@ def test_pass_hamiltonians():
 
     with pytest.raises(TypeError):
         QAOA(fakeQVM, 2, steps=1,
-             cost_ham=PauliTerm("X", 0, 1.0), ref_hamiltonian=ref_ham,
+             cost_ham=PauliTerm("X", 0, 1.0), ref_ham=ref_ham,
              rand_seed=42)
 
 


### PR DESCRIPTION
This pull request (in addition to couple of styling improvements) fixes a potential source of problems:

Default method arguments should never be mutable objects, such as []
or {} - this leads to very hard to debug situations, since these default
values are stored as a part of the function object definition and
subsequently shared between all the instances of the class.

See: http://docs.python-guide.org/en/latest/writing/gotchas/
