### PR TITLE
Update deutsch_jozsa.py

### DIFF
--- a/grove/deutsch_jozsa/deutsch_jozsa.py
+++ b/grove/deutsch_jozsa/deutsch_jozsa.py
@@ -55,7 +55,7 @@ class DeutschJosza(object):
         self._init_attr(bitstring_map)
         returned_bitstring = cxn.run_and_measure(self.deutsch_jozsa_circuit, self.computational_qubits)
         # We are only running a single shot, so we are only interested in the first element.
-        bitstring = np.array(returned_bitstring, dtype=int)
+        bitstring = returned_bitstring[0]
         constant = all([bit == 0 for bit in bitstring])
         return constant
 


### PR DESCRIPTION
In Python 3.6, the lines:
`bitstring = np.array(returned_bitstring, dtype=int)`
`constant = all([bit == 0 for bit in bitstring])`
produce an error:

> ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

due to the nested list (converting to numpy array does not fix the problem, the list must be extracted by indexing). 