### PR TITLE
Finding active qubits in a list of pauli terms

### DIFF
--- a/grove/measurements/estimation.py
+++ b/grove/measurements/estimation.py
@@ -75,10 +75,11 @@ def get_parity(pauli_terms, bitstring_results):
              `pauli_terms` associated with the n measurement results.
     :rtype: np.ndarray
     """
-    max_weight_pauli_index = np.argmax(
-        [len(term.get_qubits()) for term in pauli_terms])
-    active_qubit_indices = sorted(
-        pauli_terms[max_weight_pauli_index]._ops.keys())
+    qubit_set = []
+    for term in pauli_terms:
+        qubit_set.extend(list(term.get_qubits()))
+    active_qubit_indices = sorted(list(set(qubit_set)))
+
     index_mapper = dict(zip(active_qubit_indices,
                             range(len(active_qubit_indices))))
 


### PR DESCRIPTION
There was an error in how the map from qubit to measurement result was
constructed.

Old code would have taken a list of Pauli terms consisting of

```
(-0.019844113673352048+0j)*X0*X1*X3*Z4*Z5*X6 + (-0.4047216515044083+0j)*Z2 + (-1.0378580892109397+0j)*Z7
```

and returned the `active_qubit_indices` as [0, 1, 3, 4, 5, 6] because it
was erroneously looking for the maximal weight term instead of the union
of all qubits being examined.