### PR TITLE
Fix link to Quantum Amplitude Amplification and Estimation paper

### DIFF
--- a/grove/amplification/amplification.py
+++ b/grove/amplification/amplification.py
@@ -17,7 +17,7 @@
 """Module for amplitude amplification, for use in algorithms such as Grover's algorithm.
 
  See G. Brassard, P. Hoyer, M. Mosca (2000) `Quantum Amplitude Amplification and Estimation
- <https://arxiv.org/abs/quant-ph/0005055 arXiv:quant-ph/0005055>`_ for more information.
+ <https://arxiv.org/abs/quant-ph/0005055>`_ for more information.
 """
 import numpy as np
 import pyquil.quil as pq


### PR DESCRIPTION
Fix the link to `https://arxiv.org/abs/quant-ph/0005055` on  `http://grove-docs.readthedocs.io/en/latest/grover.html` because it goes to `https://arxiv.org/abs/quant-ph/0005055arXiv:quant-ph/0005055`