### PR TITLE
Phaseestimation update qft

### DIFF
--- a/grove/alpha/jordan_gradient/jordan_gradient.py
+++ b/grove/alpha/jordan_gradient/jordan_gradient.py
@@ -18,7 +18,7 @@ def gradient_program(f_h, precision):
     """
 
     # encode oracle values into phase
-    phase_factor = np.exp(-1.0j * 2 * np.pi * abs(f_h))
+    phase_factor = np.exp(1.0j * 2 * np.pi * abs(f_h))
     U = np.array([[phase_factor, 0],
                   [0, phase_factor]])
     p_gradient = phase_estimation(U, precision)

--- a/grove/alpha/phaseestimation/phase_estimation.py
+++ b/grove/alpha/phaseestimation/phase_estimation.py
@@ -18,7 +18,7 @@ import pyquil.quil as pq
 from pyquil.gates import H
 import numpy as np
 from math import log
-from grove.qft.fourier import qft
+from grove.qft.fourier import inverse_qft
 
 
 def controlled(m):
@@ -68,7 +68,7 @@ def phase_estimation(U, accuracy, reg_offset=0):
         # apply it
         p.inst((name, i) + tuple(U_qubits))
     # Compute the QFT
-    p = p + qft(output_qubits)
+    p = p + inverse_qft(output_qubits)
     # Perform the measurements
     for i in output_qubits:
         p.measure(i, reg_offset + i)

--- a/grove/tests/jordan_gradient/test_jordan_gradient.py
+++ b/grove/tests/jordan_gradient/test_jordan_gradient.py
@@ -17,7 +17,7 @@ def test_gradient_program():
     
     result_prog = pq.Program([H(0), H(1)])
 
-    phase_factor = np.exp(-1.0j * 2 * np.pi * abs(f_h))
+    phase_factor = np.exp(1.0j * 2 * np.pi * abs(f_h))
     U = np.array([[phase_factor, 0],
                   [0, phase_factor]])
     q_out = range(precision, precision+1)
@@ -29,8 +29,8 @@ def test_gradient_program():
         result_prog.defgate(name, cU)
         result_prog.inst((name, i) + tuple(q_out))
 
-    result_prog.inst([H(1), CPHASE(1.5707963267948966, 0, 1), H(0), 
-                     SWAP(0, 1), MEASURE(0, [0]), MEASURE(1, [1])])
+    result_prog.inst([SWAP(0, 1), H(0), CPHASE(-1.5707963267948966, 0, 1),
+                      H(1), MEASURE(0, [0]), MEASURE(1, [1])])
 
     assert(trial_prog == result_prog)
 

--- a/grove/tests/phaseestimation/test_phaseestimation.py
+++ b/grove/tests/phaseestimation/test_phaseestimation.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from pyquil.gates import H, CPHASE, SWAP, MEASURE
+import pyquil.quil as pq
+
+from grove.qft.fourier import inverse_qft
+from grove.alpha.phaseestimation.phase_estimation import controlled
+from grove.alpha.phaseestimation.phase_estimation import phase_estimation
+
+
+def test_phase_estimation():
+    phase = 0.75
+    precision = 4
+    
+    phase_factor = np.exp(1.0j * 2 * np.pi * phase)
+    U = np.array([[phase_factor, 0],
+                  [0, -1*phase_factor]])
+    
+    trial_prog = phase_estimation(U, precision)
+    
+    result_prog = pq.Program([H(i) for i in range(precision)])
+    
+    q_out = range(precision, precision+1)
+    for i in range(precision):
+        if i > 0:
+            U = np.dot(U, U)
+        cU = controlled(U)
+        name = "CONTROLLED-U{0}".format(2 ** i)
+        result_prog.defgate(name, cU)
+        result_prog.inst((name, i) + tuple(q_out))
+    
+    result_prog += inverse_qft(range(precision))
+    
+    result_prog += [MEASURE(i, [i]) for i in range(precision)]
+    
+    assert(trial_prog == result_prog)


### PR DESCRIPTION
Per #145 and #44, `phaseestimation` should use `inverse_qft`.

Also added a unit test for `phaseestimation` and updated `jordan_gradient` module/unit test as it uses `phaseestimation`.