### PR TITLE
Fix cvxpy version so semaphore passes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands=
     pip install cython==0.24.1
     pip install qutip==4.1
     pip install scs==1.2.6
-    pip install cvxpy
+    pip install cvxpy==0.4.11
 
     # backend that works without X running
     echo "backend : Agg" > ~/.config/matplotlib/matplotlibrc


### PR DESCRIPTION
Currently semaphore is failing because cvxpy's version was bumped. I think we should think up a better way to manage our dependencies, but for now if we fix the version tests should at least pass on semaphore.