### PR TITLE
Return individual pauli expected values

### DIFF
--- a/grove/measurements/estimation.py
+++ b/grove/measurements/estimation.py
@@ -100,7 +100,7 @@ def get_parity(pauli_terms, bitstring_results):
 
 
 EstimationResult = namedtuple('EstimationResult',
-                              ('expected_value', 'term_wise_expected_value',
+                              ('expected_value', 'pauli_expectations',
                                'covariance', 'variance', 'n_shots'))
 
 
@@ -118,6 +118,10 @@ def estimate_pauli_sum(pauli_terms, basis_transform_dict, program,
         \mathrm{Cov}(\hat{\langle P_{i} \rangle}, \hat{\langle P_{j} \rangle})
         \end{align}
 
+    The expectation value of each Pauli operator (term and coefficient) is
+    also returned.  It can be accessed through the named-tuple field
+    `pauli_expectations'.
+
     :param pauli_terms: list of pauli terms to measure simultaneously or a
                         PauliSum object
     :param basis_transform_dict: basis transform dictionary where the key is
@@ -131,8 +135,12 @@ def estimate_pauli_sum(pauli_terms, basis_transform_dict, program,
     :param Bool commutation_check: Optional flag toggling a safety check
                                    ensuring all terms in `pauli_terms`
                                    commute with each other
-    :return: estimated expected value, covariance matrix, variance of the
-             estimator, and the number of shots taken
+    :return: estimated expected value, expected value of each Pauli term in
+             the sum, covariance matrix, variance of the estimator, and the
+             number of shots taken.  The objected returned is a named tuple with
+             field names as follows: expected_value, pauli_expectations,
+             covariance, variance, n_shots
+    :rtype: EstimationResult
     """
     if not isinstance(pauli_terms, (list, PauliSum)):
         raise TypeError("pauli_terms needs to be a list or a PauliSum")
@@ -181,7 +189,7 @@ def estimate_pauli_sum(pauli_terms, basis_transform_dict, program,
         sample_variance = coeff_vec.T.dot(covariance_mat).dot(coeff_vec) / results.shape[1]
 
     return EstimationResult(expected_value=coeff_vec.T.dot(np.mean(results, axis=1)),
-                            term_wise_expected_value=np.mean(results, axis=1),
+                            pauli_expectations=np.multiply(coeff_vec, np.mean(results, axis=1)),
                             covariance=covariance_mat,
                             variance=sample_variance,
                             n_shots=results.shape[1])

--- a/grove/measurements/estimation.py
+++ b/grove/measurements/estimation.py
@@ -100,7 +100,8 @@ def get_parity(pauli_terms, bitstring_results):
 
 
 EstimationResult = namedtuple('EstimationResult',
-                              ('expected_value', 'covariance', 'variance', 'n_shots'))
+                              ('expected_value', 'term_wise_expected_value',
+                               'covariance', 'variance', 'n_shots'))
 
 
 def estimate_pauli_sum(pauli_terms, basis_transform_dict, program,
@@ -180,6 +181,7 @@ def estimate_pauli_sum(pauli_terms, basis_transform_dict, program,
         sample_variance = coeff_vec.T.dot(covariance_mat).dot(coeff_vec) / results.shape[1]
 
     return EstimationResult(expected_value=coeff_vec.T.dot(np.mean(results, axis=1)),
+                            term_wise_expected_value=np.mean(results, axis=1),
                             covariance=covariance_mat,
                             variance=sample_variance,
                             n_shots=results.shape[1])

--- a/grove/measurements/estimation.py
+++ b/grove/measurements/estimation.py
@@ -139,7 +139,8 @@ def estimate_pauli_sum(pauli_terms, basis_transform_dict, program,
              the sum, covariance matrix, variance of the estimator, and the
              number of shots taken.  The objected returned is a named tuple with
              field names as follows: expected_value, pauli_expectations,
-             covariance, variance, n_shots
+             covariance, variance, n_shots.
+             `expected_value' == coef_vec.dot(pauli_expectations)
     :rtype: EstimationResult
     """
     if not isinstance(pauli_terms, (list, PauliSum)):

--- a/grove/tests/measurements/test_estimation.py
+++ b/grove/tests/measurements/test_estimation.py
@@ -116,7 +116,7 @@ def test_estimate_pauli_sum():
 
     fakeQVM = Mock(spec=QVMConnection())
     fakeQVM.run = Mock(return_value=two_qubit_measurements)
-    mean, cov, estimator_var, shots = estimate_pauli_sum(pauli_terms,
+    mean, means, cov, estimator_var, shots = estimate_pauli_sum(pauli_terms,
                                                          {0: 'Z', 1: 'Z'},
                                                          Program(),
                                                          1.0E-1, fakeQVM)
@@ -128,13 +128,14 @@ def test_estimate_pauli_sum():
 
     assert np.allclose(np.cov(parity_results), cov)
     assert np.isclose(np.sum(np.mean(parity_results, axis=1)), mean)
+    assert np.allclose(np.mean(parity_results, axis=1), means)
     assert np.isclose(shots, n)
     variance_to_beat = np.sum(cov) / n
     assert np.isclose(variance_to_beat, estimator_var)
 
     # Double the shots by ever so slightly decreasing variance bound
     double_two_q_measurements = two_qubit_measurements + two_qubit_measurements
-    mean, cov, estimator_var, shots = estimate_pauli_sum(pauli_terms,
+    mean, means, cov, estimator_var, shots = estimate_pauli_sum(pauli_terms,
                                                          {0: 'Z', 1: 'Z'},
                                                          Program(),
                                                          variance_to_beat - \
@@ -148,6 +149,7 @@ def test_estimate_pauli_sum():
 
     assert np.allclose(np.cov(parity_results), cov)
     assert np.isclose(np.sum(np.mean(parity_results, axis=1)), mean)
+    assert np.allclose(np.mean(parity_results, axis=1), means)
     assert np.isclose(shots, 2 * n)
     assert np.isclose(np.sum(cov) / (2 * n), estimator_var)
 


### PR DESCRIPTION
Many applications we don't necessarily want the sum of expected values
but a list of expected values.  the estimate_pauli_sum functionality can
be expanded in a very simple way to return the desired values by
augmenting the named tuple