### PR TITLE
fix use np.array.all() instead of Python all()

### DIFF
--- a/grove/deutsch_jozsa/deutsch_jozsa.py
+++ b/grove/deutsch_jozsa/deutsch_jozsa.py
@@ -56,8 +56,8 @@ class DeutschJosza(object):
         returned_bitstring = cxn.run_and_measure(self.deutsch_jozsa_circuit, self.computational_qubits)
         # We are only running a single shot, so we are only interested in the first element.
         bitstring = np.array(returned_bitstring, dtype=int)
-        constant = all([bit == 0 for bit in bitstring])
-        return constant
+        constant = np.array([bit == 0 for bit in bitstring])
+        return constant.all()
 
     def _init_attr(self, bitstring_map):
         """


### PR DESCRIPTION
Fix this error using Numpy when i call to is_constant in deutsch jozsa:

`/usr/local/lib/python2.7/dist-packages/grove/deutsch_jozsa/deutsch_jozsa.pyc in is_constant(self, cxn, bitstring_map)
     57         # We are only running a single shot, so we are only interested in the first element.
     58         bitstring = np.array(returned_bitstring, dtype=int)
---> 59         constant = all([bit == 0 for bit in bitstring])
     60         return constant
     61 

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
`

Now it uses all function from Numpy instead of builtin all function.