### PR TITLE
Fixing wrong indentation in VQE expectation value

### DIFF
--- a/grove/pyvqe/vqe.py
+++ b/grove/pyvqe/vqe.py
@@ -263,7 +263,7 @@ class VQE(object):
                             elif gate == 'Y':
                                 meas_basis_change.inst(RX(np.pi / 2, index))
 
-                            meas_outcome = \
+                        meas_outcome = \
                                 expectation_from_sampling(pyquil_prog + meas_basis_change,
                                                           qubits_to_measure,
                                                           qvm,


### PR DESCRIPTION
With commit `d8f15511bb7cbc839380d110080b1a0b7687a1ed` has been added an extra indentation to the call of `expectation_from_sampling` moving it inside the above for loop.