### PR TITLE
Bug fix in vqe expectation

### DIFF
--- a/grove/pyvqe/vqe.py
+++ b/grove/pyvqe/vqe.py
@@ -225,10 +225,7 @@ class VQE(object):
                 pauli_sum = PauliSum([pauli_sum])
 
             if samples is None:
-                result_overlaps = WavefunctionSimulator().expectation(pyquil_prog, pauli_sum.terms)
-                assert result_overlaps.size == len(pauli_sum),\
-                    """Somehow we didn't get the correct number of results back from the QVM"""
-                expectation = np.sum(result_overlaps)
+                expectation = WavefunctionSimulator().expectation(pyquil_prog, pauli_sum)
                 return expectation.real
             else:
                 if not isinstance(samples, int):

--- a/grove/pyvqe/vqe.py
+++ b/grove/pyvqe/vqe.py
@@ -249,11 +249,11 @@ class VQE(object):
                             elif gate == 'Y':
                                 meas_basis_change.inst(RX(np.pi / 2, index))
 
-                            meas_outcome = \
-                                expectation_from_sampling(pyquil_prog + meas_basis_change,
-                                                          qubits_to_measure,
-                                                          qc,
-                                                          samples)
+                        meas_outcome = \
+                            expectation_from_sampling(pyquil_prog + meas_basis_change,
+                                                      qubits_to_measure,
+                                                      qc,
+                                                      samples)
 
                     expectation += term.coefficient * meas_outcome
 

--- a/grove/pyvqe/vqe.py
+++ b/grove/pyvqe/vqe.py
@@ -225,21 +225,11 @@ class VQE(object):
                 pauli_sum = PauliSum([pauli_sum])
 
             if samples is None:
-                operator_progs = []
-                operator_coeffs = []
-                for p_term in pauli_sum.terms:
-                    op_prog = Program()
-                    for qindex, op in p_term:
-                        op_prog.inst(STANDARD_GATES[op](qindex))
-                    operator_progs.append(op_prog)
-                    operator_coeffs.append(p_term.coefficient)
-
                 result_overlaps = WavefunctionSimulator().expectation(pyquil_prog, pauli_sum.terms)
                 result_overlaps = list(result_overlaps)
-                assert len(result_overlaps) == len(operator_progs),\
+                assert len(result_overlaps) == len(pauli_sum),\
                     """Somehow we didn't get the correct number of results back from the QVM"""
-                expectation = sum(list(map(lambda x: x[0] * x[1],
-                                           zip(result_overlaps, operator_coeffs))))
+                expectation = sum(result_overlaps)
                 return expectation.real
             else:
                 if not isinstance(samples, int):

--- a/grove/pyvqe/vqe.py
+++ b/grove/pyvqe/vqe.py
@@ -226,10 +226,9 @@ class VQE(object):
 
             if samples is None:
                 result_overlaps = WavefunctionSimulator().expectation(pyquil_prog, pauli_sum.terms)
-                result_overlaps = list(result_overlaps)
-                assert len(result_overlaps) == len(pauli_sum),\
+                assert result_overlaps.size == len(pauli_sum),\
                     """Somehow we didn't get the correct number of results back from the QVM"""
-                expectation = sum(result_overlaps)
+                expectation = np.sum(result_overlaps)
                 return expectation.real
             else:
                 if not isinstance(samples, int):


### PR DESCRIPTION
We found a bug while using vqe with samples=None. The current version uses the expectation method of WavefunctionSimulator from pyquil.api to calculate the expectation values of every term (including coefficients) in the PauliSum and then weights these with the coefficients of the terms. Thus, the coefficients are, effectively, squared, which results in an incorrect expectation value of the PauliSum. The proposed solution is to let the expectation method of WavefunctionSimulator handle everything since it supports PauliSums.

Moreover, we found that vqe expectation made some unnecessary computations on the QC, probably due to an accidental indentation (see last commit).