### PR TITLE
Bump grove version to v1.8.0

### DIFF
--- a/grove/__init__.py
+++ b/grove/__init__.py
@@ -13,4 +13,4 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-__version__ = '2.0.0b0'
+__version__ = '1.8.0'


### PR DESCRIPTION
Bump the grove version to a new v1.x value so that `pip install quantum-grove` gives users a version that's pyQuil 2.0 compatible. 