### PR TITLE
Fix tests. Expect DAGGER modifier rather than daggered gate defn

### DIFF
--- a/grove/tests/amplification/test_amplification.py
+++ b/grove/tests/amplification/test_amplification.py
@@ -56,7 +56,18 @@ def test_amplify():
     Test the generic usage of amplify
     """
     # Essentially Grover's to select 011 or 111
-    desired = (triple_hadamard.dagger()
+
+    # Note: slight hack here. Technically DAGGER H 0 is equivalent to
+    # H 0, however since many tests simply test for string equality
+    # (not program semantic equality) "DAGGER H 0" != "H 0". The
+    # Program.dagger() operation was changed to use the DAGGER keyword
+    # in Quil, rather than manually calculate and insert the
+    # appropriate matrix into the target program. Hence, old tests
+    # expect that Program("H 0").dagger() == Program("H 0"), but new
+    # pyquil produces Program("H 0").dagger() == Program("DAGGER H
+    # 0"). If anything looks weird below, it's probably because of
+    # this.
+    desired = (triple_hadamard[::-1]
                + cz_gate
                + triple_hadamard.dagger()
                + diffusion_program(qubits)
@@ -67,7 +78,7 @@ def test_amplify():
                + diffusion_program(qubits).instructions
                + triple_hadamard)
     created = amplification_circuit(triple_hadamard, cz_gate, qubits, iters)
-    assert desired == created
+    assert desired.out() == created.out()
 
 
 def test_trivial_diffusion():

--- a/grove/tests/utils/test_utility_programs.py
+++ b/grove/tests/utils/test_utility_programs.py
@@ -37,7 +37,8 @@ def double_control_test(instructions, target_qubit, control_qubit_one, control_q
     assert instructions[1].name == CNOT(control_qubit_one, control_qubit_two).name
     assert instructions[1].qubits == [control_qubit_one, control_qubit_two]
 
-    assert instructions[2].name == cpg.format_gate_name("C", sqrt_z) + '-INV'
+    assert instructions[2].name == cpg.format_gate_name("C", sqrt_z)
+    assert instructions[2].modifiers == ["DAGGER"]
     assert instructions[2].qubits == [control_qubit_two, target_qubit]
 
     assert instructions[3].name == CNOT(control_qubit_one, control_qubit_two).name

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 
 from setuptools import setup, find_packages
 from grove import __version__
-
+ 
 setup(
     name="quantum-grove",
     version=__version__,


### PR DESCRIPTION
The tests will forever be fragile, because they often assert that two programs are equivalent if their textual representations (Quil code) are the same. This means that `Program("DAGGER H 0") != Program("H 0")`.

@amyfbrown 